### PR TITLE
RFC: Use :robot: instead of [automated]

### DIFF
--- a/src/bump-stdlibs.jl
+++ b/src/bump-stdlibs.jl
@@ -95,8 +95,8 @@ function _bump_single_stdlib(stdlib::StdlibInfo;
             cd("FORK")
             run(`git checkout $(upstream_julia_repo_default_branch)`)
             assert_current_branch_is(upstream_julia_repo_default_branch)
-            pr_title = "[automated] Bump the $(name) stdlib to $(stdlib_latest_commit_short)$(pr_title_suffix)"
-            pr_title_long = "[automated] Bump the $(name) stdlib to $(stdlib_latest_commit)$(pr_title_suffix)"
+            pr_title = "🤖 Bump the $(name) stdlib to $(stdlib_latest_commit_short)$(pr_title_suffix)"
+            pr_title_long = "🤖 Bump the $(name) stdlib to $(stdlib_latest_commit)$(pr_title_suffix)"
             pr_branch = "BumpStdlibs/$(name)-$(stdlib_latest_commit_short)$(pr_branch_suffix)"
             pr_body = string(
                 "```\n",


### PR DESCRIPTION
Use the 🤖 emoji instead of `[automated]` in the PR title, which makes the PR title shorter and look better (in my opinion). Will look like

![pr-emoji](https://user-images.githubusercontent.com/147757/100565431-79cb3100-3328-11eb-8536-9f327061a072.png)
![pr-automated](https://user-images.githubusercontent.com/147757/100565428-789a0400-3328-11eb-8467-38759f09c302.png)

And in the PR list:

![issues-emoji](https://user-images.githubusercontent.com/147757/100565433-7afc5e00-3328-11eb-8b25-4efb3cc6926b.png)
![issues-automated](https://user-images.githubusercontent.com/147757/100565432-7a63c780-3328-11eb-9dda-076aac816fad.png)

I have no idea if just swapping it out in the string like this will work as intended, so I would not merge this hastily, unless you know that it does work (assuming you think this is a good idea in the first place).